### PR TITLE
Make the building of tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ target_include_directories(router INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 
+set(ROUTER_MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(ROUTER_MASTER_PROJECT ON)
+endif()
+
+option(ROUTER_TEST "Build the tests" ${ROUTER_MASTER_PROJECT})
+
 # msvc does not support normal options
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # set warning level to 4
@@ -77,4 +84,6 @@ install(
         lib/cmake/router
 )
 
-add_subdirectory(tests)
+if (ROUTER_TEST)
+    add_subdirectory(tests)
+endif()


### PR DESCRIPTION
The tests are enabled when the project is being build directly, if it is
build as a dependency of another project (i.e. through add_subdirectory)
the tests are disabled by default.

The test build can be controlled using the ROUTER_TEST cache variable.