### PR TITLE
Add table::set_not_found to handle routing unmatched paths

### DIFF
--- a/tests/table.cpp
+++ b/tests/table.cpp
@@ -14,6 +14,21 @@ TEST_CASE("paths can be matched", "[path]")
         REQUIRE_THROWS_AS(table.route("/test"), std::out_of_range);
     }
 
+    SECTION("404 handler") {
+        struct not_found_handler
+        {
+            void handle_404() { handler_invoked = true; }
+            bool handler_invoked{ false };
+        };
+
+        not_found_handler tester;
+
+        table.set_not_found<&not_found_handler::handle_404>(&tester);
+        table.route("/wherever/not/found");
+
+        REQUIRE(tester.handler_invoked == true);
+    }
+
     SECTION("invoking a member function") {
         struct callback_tester
         {


### PR DESCRIPTION
This adds the functionality of installing a callback to be invoked whenever a path is routed not matching any of the registered patterns.