### PR TITLE
Fix duplicate definition of process_field for std::string_view

### DIFF
--- a/include/router/variables.h
+++ b/include/router/variables.h
@@ -14,7 +14,7 @@ namespace router {
      *  @param  input   The slug data
      *  @param  output  The field to set
      */
-    void process_field(std::string_view input, std::string& output)
+    inline void process_field(std::string_view input, std::string& output)
     {
         // assign the input data to the output string
         output.assign(input);


### PR DESCRIPTION
This breaks linking when variables.h is included in multiple
compilation units.

Fixes #7