### PR TITLE
Only set warnings options when building as root project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,19 +21,24 @@ endif()
 
 option(ROUTER_TEST "Build the tests" ${ROUTER_MASTER_PROJECT})
 
-# msvc does not support normal options
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    # set warning level to 4
-    target_compile_options(router INTERFACE /W4)
-else()
-	# include helper to enable only options which are supported
-	include(cmake/target_supported_compile_options.cmake)
+# only override the warning options if we're build as the master
+# project, in other cases leave them alone since we might be added
+# to a project with laxer standards for dealing with warnings
+if (ROUTER_MASTER_PROJECT)
+    # msvc does not support normal options
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        # set warning level to 4
+        target_compile_options(router INTERFACE /W4)
+    else()
+        # include helper to enable only options which are supported
+        include(cmake/target_supported_compile_options.cmake)
 
-    # try all the regular options and enable them if possible
-    target_supported_compile_options(router INTERFACE -Wall)
-    target_supported_compile_options(router INTERFACE -Wextra)
-    target_supported_compile_options(router INTERFACE -Wdeprecated)
-    target_supported_compile_options(router INTERFACE -Wdocumentation)
+        # try all the regular options and enable them if possible
+        target_supported_compile_options(router INTERFACE -Wall)
+        target_supported_compile_options(router INTERFACE -Wextra)
+        target_supported_compile_options(router INTERFACE -Wdeprecated)
+        target_supported_compile_options(router INTERFACE -Wdocumentation)
+    endif()
 endif()
 
 install(


### PR DESCRIPTION
If we are used directly in another project (e.g. using add_subdirectory)
we don't change the warning options. This prevents enabling warnings in
external code when using this project.