### PR TITLE
Introduce method-based routing

### DIFF
--- a/include/router/path_callback.h
+++ b/include/router/path_callback.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "function_traits.h"
+#include "wrap_callback.h"
+#include <functional>
+#include <string_view>
+#include <vector>
+
+
+namespace router {
+
+    /**
+     *  In-place option used for the constructor
+     */
+    template <auto>
+    struct in_place_value {};
+
+    /**
+     *  Undefined templated class for specializing
+     *  into a function-like template class
+     */
+    template <class>
+    class path_callback;
+
+    /**
+     *  A callback, wrapped to be used with a path
+     */
+    template <class return_type, class... arguments>
+    class path_callback<return_type(arguments...)>
+    {
+        public:
+            /**
+             *  Default constructor
+             */
+            path_callback() = default;
+
+            /**
+             *  Construct with a free function
+             *
+             *  @tparam callback    The callback to install
+             */
+            template <auto callback, typename = std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>>>
+            path_callback(in_place_value<callback>) noexcept :
+                _callback{ &wrap_callback<callback> }
+            {}
+
+            /**
+             *  Construct with a member function
+             *
+             *  @tparam callback    The callback to install
+             *  @param  instance    The instance to invoke on
+             */
+            template <auto callback, typename = std::enable_if_t<std::is_member_function_pointer_v<decltype(callback)>>>
+            path_callback(in_place_value<callback>, typename function_traits<decltype(callback)>::member_type* instance) noexcept :
+                _callback{ &wrap_callback<callback> },
+                _instance{ instance }
+            {}
+
+            /**
+             *  Set a free function to be invoked
+             *
+             *  @tparam callback    The callback to install
+             */
+            template <auto callback>
+            std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>>
+            set() noexcept
+            {
+                _callback = &wrap_callback<callback>;
+            }
+
+            /**
+             *  Set a member function to be invoked
+             *
+             *  @tparam callback    The callback to install
+             *  @param  instance    The instance to invoke on
+             */
+            template <auto callback>
+            std::enable_if_t<std::is_member_function_pointer_v<decltype(callback)>>
+            set(typename function_traits<decltype(callback)>::member_type* instance) noexcept
+            {
+                _callback = &wrap_callback<callback>;
+                _instance = instance;
+            }
+
+            /**
+             *  Check if we have a valid callback installed
+             *
+             *  @return Whether a callback was set
+             */
+            bool valid() const noexcept { return _callback != nullptr; }
+            operator bool() const noexcept { return valid(); }
+
+            /**
+             *  Invoke the installed function
+             *
+             *  @param  slugs       The slugs parsed from the path
+             *  @param  parameters  The parameters to the callback
+             *  @throws std::bad_function_call  In case no member function is installed
+             */
+            return_type operator()(const std::vector<std::string_view>& slugs, arguments&&... parameters) const
+            {
+                // check whether we have a valid callback
+                if (_callback == nullptr) {
+                    throw std::bad_function_call{};
+                }
+
+                // invoke the callback
+                return _callback(slugs, _instance, std::forward<arguments>(parameters)...);
+            }
+        private:
+            /**
+             *  Alias for a wrapped callback
+             */
+            using wrapped_callback = return_type(*)(const std::vector<std::string_view>& slugs, void* instance, arguments&&... parameters);
+
+            wrapped_callback    _callback{};    // the callback to invoke
+            void*               _instance{};    // the instance to invoke on (empty for non-member functions)
+    };
+
+}

--- a/include/router/path_map.h
+++ b/include/router/path_map.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+#include "path.h"
+
+
+namespace router {
+
+    /**
+     *  A class mapping paths to something else
+     */
+    template <typename V>
+    class path_map
+    {
+        public:
+            using value_type = V;
+
+            /**
+             *  Add a value to the map
+             *
+             *  @param  endpoint    The endpoint to add
+             *  @param  parameters  The parameters to create the value
+             */
+            template <typename... arguments>
+            value_type& add(std::string_view endpoint, arguments&&... parameters)
+            {
+                // create the path to route
+                path    path    { endpoint  };
+
+                // does the endpoint contain a fixed prefix?
+                if (path.prefix().empty()) {
+                    // there is no prefix to sort on so
+                    // we add this to the unsorted list
+                     return _unsorted_paths.emplace_back(
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::move(path)),
+                        std::forward_as_tuple(std::forward<arguments>(parameters)...)
+                    ).second;
+                } else {
+                    // find the element to insert before
+                    auto iter = std::lower_bound(begin(_prefixed_paths), end(_prefixed_paths), path, [](const auto& a, const auto& b) {
+                        // endpoints are sorted by prefix
+                        return std::get<0>(a).prefix() < b.prefix();
+                    });
+
+                    // add it to the sorted list before the found element
+                    return _prefixed_paths.emplace(iter,
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::move(path)),
+                        std::forward_as_tuple(std::forward<arguments>(parameters)...)
+                    )->second;
+                }
+            }
+
+            /**
+             *  Find an entry in the map
+             *
+             *  @param  slugs       The slugs to fill if found
+             *  @param  endpoint    The endpoint to lookup
+             *  @return The found value, or a nullptr
+             */
+            const value_type* find(std::vector<std::string_view>& slugs, std::string_view endpoint) const noexcept
+            {
+                // find the first possibly matching entry by prefix
+                auto iter = std::lower_bound(begin(_prefixed_paths), end(_prefixed_paths), endpoint, [](const auto& a, const auto& b) {
+                    // check whether the prefix comes before the given endpoint
+                    return std::get<0>(a).prefix() < b.substr(0, std::get<0>(a).prefix().size());
+                });
+
+                // try all valid matches
+                while (iter != end(_prefixed_paths)) {
+                    // retrieve the path, callback and instance
+                    const auto& [path, value] = *iter;
+
+                    // if the prefix no longer matches we have exhausted all options
+                    if (!path.match_prefix(endpoint)) {
+                        // stop now to avoid expensive regex calls
+                        break;
+                    }
+
+                    // try to match the path to the given endpoint
+                    if (path.match(endpoint, slugs)) {
+                        // we matched the endpoint, return the handler
+                        return &value;
+                    }
+
+                    // move on to the next entry
+                    ++iter;
+                }
+
+                // none of the prefixed paths matched, so try the
+                // unsorted paths without a known prefix
+                for (const auto& [path, value] : _unsorted_paths) {
+                    // try to match the path to the given endpoint
+                    if (path.match(endpoint, slugs)) {
+                        // we matched the endpoint, return the handler
+                        return &value;
+                    }
+                }
+
+                // none of the paths matched
+                return nullptr;
+            }
+        private:
+            /**
+             *  The entry type we store inside the map, we store both the
+             *  path and the given value type together in a flat structure
+             */
+            using entry = std::pair<path, value_type>;
+
+            std::vector<entry>  _prefixed_paths;    // a sorted list of paths with prefixes
+            std::vector<entry>  _unsorted_paths;    // paths without a prefix, not sorted
+    };
+
+}

--- a/include/router/proxy.h
+++ b/include/router/proxy.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "variadic_lookup.h"
+#include "function_traits.h"
+#include "wrap_callback.h"
+#include "path_callback.h"
+#include <string_view>
+#include <vector>
+#include <array>
+
+
+namespace router {
+
+    /**
+     *  Undefined templated class for specializing
+     *  into a function-like template class
+     */
+    template <class, auto, auto...>
+    class proxy;
+
+	/**
+	 *  A proxy for forwarding a single route to a set of
+	 *  different callbacks, depending on an extra method.
+	 */
+    template <class return_type, class... arguments, auto first, decltype(first)... rest>
+	class proxy<return_type(arguments...), first, rest...>
+	{
+        public:
+            /**
+             *  Alias for the callback type proxied to
+             */
+            using callback_type = path_callback<return_type(arguments...)>;
+
+            /**
+             *  Retrieve an installed handler
+             *
+             *  @param  method  The method to retrieve the handler for
+             *  @return The handler, or a nullptr if not set
+             */
+            const callback_type& get(decltype(first) method) const noexcept
+            {
+                // the index to retrieve
+                auto index = method_index(method);
+
+                // retrieve the callback
+                return _callbacks[index];
+            }
+
+            /**
+             *  Set up a handler
+             *
+             *  @tparam method      The method to register under
+             *  @tparam callback    The callback to register
+             */
+            template <decltype(first) method, auto callback>
+            std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>, proxy&>
+            set() noexcept
+            {
+                // the index to store under
+                constexpr auto index = method_index<method>();
+
+                // wrap and store the callback
+                _callbacks[index].template set<callback>();
+
+                // allow chaining
+                return *this;
+            }
+
+            /**
+             *  Set up a handler
+             *
+             *  @tparam method      The method to register under
+             *  @tparam callback    The callback to register
+             *  @param  instance    The instance to invoke the callback on
+             */
+            template <decltype(first) method, auto callback>
+            std::enable_if_t<std::is_member_function_pointer_v<decltype(callback)>, proxy&>
+            set(typename function_traits<decltype(callback)>::member_type* instance) noexcept
+            {
+                // the index to store under
+                constexpr auto index = method_index<method>();
+
+                // wrap and store the callback
+                _callbacks[index].template set<callback>(instance);
+
+                // allow chaining
+                return *this;
+            }
+        private:
+            /**
+             *  Retrieve the index for the method
+             *  in the list of methods
+             *
+             *  @param  method The method to lookup
+             */
+            static std::size_t method_index(decltype(first) method)
+            {
+                return variadic_lookup<0, first, rest...>(method);
+            }
+
+            /**
+             *  Retrieve the index for the method
+             *  in the list of methods
+             *
+             *  @tparam method  The property to lookup
+             */
+            template <decltype(first) method>
+            constexpr static std::size_t method_index()
+            {
+                return variadic_lookup<method, first, rest...>();
+            }
+
+            /**
+             *  The number of available options, note that we
+             *  add one to the count for the first argument
+             */
+            constexpr static std::size_t count = 1 + sizeof...(rest);
+
+            /**
+             *  All the registered callbacks
+             */
+            std::array<callback_type, count> _callbacks{};
+	};
+
+}

--- a/include/router/table.h
+++ b/include/router/table.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <algorithm>
 #include <vector>
-#include <tuple>
 #include "path.h"
-#include "variables.h"
+#include "proxy.h"
+#include "path_map.h"
+#include "path_callback.h"
 #include "function_traits.h"
 
 
@@ -35,9 +35,9 @@ namespace router {
             std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>>
             add(std::string_view endpoint)
             {
-                // add the endpoint using the wrapped callback, since
-                // the callback is not a member functio we need no instance
-                add(&table::wrap_callback<callback>, endpoint, nullptr);
+                // add the endpoint using the wrapped callback, since 
+                // the callback is not a member function we need no instance
+                _paths.add(endpoint, in_place_value<callback>{});
             }
 
             /**
@@ -52,7 +52,7 @@ namespace router {
             add(std::string_view endpoint, typename function_traits<decltype(callback)>::member_type* instance)
             {
                 // add the endpoint using the wrapped callback
-                add(&table::wrap_callback<callback>, endpoint, instance);
+                _paths.add(endpoint, in_place_value<callback>{}, instance);
             }
 
             /**
@@ -65,8 +65,7 @@ namespace router {
             set_not_found()
             {
                 // store the function pointer, there is no instance
-                _not_found_handler.first    = &table::wrap_callback<callback>;
-                _not_found_handler.second   = nullptr;
+                _not_found_handler.template set<callback>();
             }
 
             /**
@@ -80,8 +79,7 @@ namespace router {
             set_not_found(typename function_traits<decltype(callback)>::member_type* instance)
             {
                 // store the function pointer and instance
-                _not_found_handler.first    = &table::wrap_callback<callback>;
-                _not_found_handler.second   = instance;
+                _not_found_handler.template set<callback>(instance);
             }
 
             /**
@@ -97,10 +95,10 @@ namespace router {
             bool routable(std::string_view endpoint) const noexcept
             {
                 // find the handler for the given endpoint
-                auto [callback, _] = get_handler(endpoint);
+                auto callback= get_handler(endpoint);
 
                 // check whether the callback is valid
-                return callback != nullptr;
+                return callback.valid();
             }
 
             /**
@@ -115,7 +113,7 @@ namespace router {
              */
             bool has_not_found_handler() const noexcept
             {
-                return _not_found_handler.first != nullptr;
+                return _not_found_handler.valid();
             }
 
             /**
@@ -129,18 +127,15 @@ namespace router {
             return_type route(std::string_view endpoint, arguments... parameters) const
             {
                 // find the handler for the given endpoint
-                if (auto [callback, instance] = get_handler(endpoint); callback != nullptr) {
+                if (auto callback= get_handler(endpoint); callback.valid()) {
                     // invoke the callback
-                    return callback(slugs(), instance, std::forward<arguments>(parameters)...);
+                    return callback(slugs(), std::forward<arguments>(parameters)...);
                 }
 
                 // do we have a handler for endpoints that aren't registered
-                if (_not_found_handler.first != nullptr) {
-                    // extract the callback and instance
-                    auto [callback, instance] = _not_found_handler;
-
+                if (_not_found_handler) {
                     // invoke the handler
-                    return callback({}, instance, std::forward<arguments>(parameters)...);
+                    return _not_found_handler({}, std::forward<arguments>(parameters)...);
                 }
 
                 // none of the paths matched
@@ -148,124 +143,9 @@ namespace router {
             }
         private:
             /**
-             *  Alias for a wrapped callback
+             *  Alias for the callback type used by the routing table
              */
-            using wrapped_callback = return_type(*)(const std::vector<std::string_view>& slugs, void* instance, arguments&&... parameters);
-
-            /**
-             *  Alias for a routed path and the callback
-             */
-            using entry = std::tuple<path, wrapped_callback, void*>;
-
-            /**
-             *  Fallback handler for endpoint not registered
-             */
-            using not_found_handler = std::pair<wrapped_callback, void*>;
-
-            /**
-             *  Wrap a callback to create a uniform handler
-             *
-             *  @tparam callback    The callback to wrap
-             *  @param  slugs       The slug data from the target
-             *  @param  instance    The instance to invoke the callback on
-             *  @param  parameters  Additional arguments to pass to the callback
-             */
-            template <auto callback>
-            static return_type wrap_callback(const std::vector<std::string_view>& slugs, void* instance, arguments&&... parameters)
-            {
-                // the number of arguments our callback function takes
-                // ignoring the extra variable parameter it may take
-                constexpr std::size_t arity = sizeof...(arguments);
-
-                // traits for the callback function, and the data type used for the variables
-                using traits = function_traits<decltype(callback)>;
-
-                // does the callback require slug parsing?
-                if constexpr (traits::arity == arity) {
-                    // is it a member function?
-                    if constexpr (!traits::is_member_function) {
-                        // it is not, we can invoke the callback directly
-                        return callback(std::forward<arguments>(parameters)...);
-                    } else {
-                        // invoke the function on the given instance
-                        return (static_cast<typename traits::member_type*>(instance)->*callback)(std::forward<arguments>(parameters)...);
-                    }
-                } else if constexpr (traits::arity == arity + 1 && (is_dto_type_v<std::remove_reference_t<typename traits::template argument_type<arity>>> || is_dto_tuple_v<std::remove_reference_t<typename traits::template argument_type<arity>>>)) {
-                    // determine the type used for the slug data, this comes as the optional
-                    // last parameter the function may take, elements are zero-based
-                    using variable_type = std::remove_reference_t<typename traits::template argument_type<arity>>;
-
-                    // create the variables to be filled and try to match the target
-                    variable_type variables{};
-
-                    // parse the variables
-                    to_dto(slugs, variables);
-
-                    // is it a member function?
-                    if constexpr (!traits::is_member_function) {
-                        // invoke the wrapped callback and return the result
-                        return callback(std::forward<arguments>(parameters)..., std::move(variables));
-                    } else {
-                        // invoke the function on the given instance
-                        return (static_cast<typename traits::member_type*>(instance)->*callback)(std::forward<arguments>(parameters)..., std::move(variables));
-                    }
-                } else {
-                    // the variable type is a tuple of the slug arguments
-                    // which is unpacked later using std::apply
-                    using variable_type = typename traits::template arguments_slice<arity>;
-
-                    // create the variables to be filled and try to match the target
-                    variable_type variables{};
-
-                    // parse the variables
-                    to_dto(slugs, variables);
-
-                    // is it a member function?
-                    if constexpr (!traits::is_member_function) {
-                        // invoke the wrapped callback and return the result
-                        return std::apply(callback, std::tuple_cat(
-                            std::forward_as_tuple(std::forward<arguments>(parameters)...),
-                            std::move(variables)
-                        ));
-                    } else {
-                        // invoke the function on the given instance
-                        return std::apply(callback, std::tuple_cat(
-                            std::forward_as_tuple(static_cast<typename traits::member_type*>(instance)),
-                            std::forward_as_tuple(std::forward<arguments>(parameters)...),
-                            std::move(variables)
-                        ));
-                    }
-                }
-            }
-
-            /**
-             *  Add an endpoint to the routing table
-             *
-             *  @param  callback    The callback to route to
-             *  @param  endpoint    The path to add
-             *  @param  instance    The instance to invoke the callback on
-             */
-            void add(wrapped_callback callback, std::string_view endpoint, void* instance)
-            {
-                // create the path to route
-                path    path    { endpoint  };
-
-                // does the endpoint contain a fixed prefix?
-                if (path.prefix().empty()) {
-                    // there is no prefix to sort on so
-                    // we add this to the unsorted list
-                    _unsorted_paths.emplace_back(std::move(path), callback, instance);
-                } else {
-                    // find the element to insert before
-                    auto iter = std::lower_bound(begin(_prefixed_paths), end(_prefixed_paths), path, [](const auto& a, const auto& b) {
-                        // endpoints are sorted by prefix
-                        return std::get<0>(a).prefix() < b.prefix();
-                    });
-
-                    // add it to the sorted list before the found element
-                    _prefixed_paths.emplace(iter, std::move(path), callback, instance);
-                }
-            }
+            using callback_type = path_callback<return_type(arguments...)>;
 
             /**
              *  Retrieve the handler for a specific endpoint
@@ -276,47 +156,13 @@ namespace router {
              *  @param  endpoint    The endpoint to find
              *  @return The found match, which may be invalid
              */
-            std::pair<wrapped_callback, void*> get_handler(std::string_view endpoint) const noexcept
+            callback_type get_handler(std::string_view endpoint) const noexcept
             {
-                // find the first possibly matching entry by prefix
-                auto iter = std::lower_bound(begin(_prefixed_paths), end(_prefixed_paths), endpoint, [](const auto& a, const auto& b) {
-                    // check whether the prefix comes before the given endpoint
-                    return std::get<0>(a).prefix() < b.substr(0, std::get<0>(a).prefix().size());
-                });
-
-                // try all valid matches
-                while (iter != end(_prefixed_paths)) {
-                    // retrieve the path, callback and instance
-                    const auto& [path, callback, instance] = *iter;
-
-                    // if the prefix no longer matches we have exhausted all options
-                    if (!path.match_prefix(endpoint)) {
-                        // stop now to avoid expensive regex calls
-                        break;
-                    }
-
-                    // try to match the path to the given endpoint
-                    if (path.match(endpoint, slugs())) {
-                        // we matched the endpoint, return the handler
-                        return { callback, instance };
-                    }
-
-                    // move on to the next entry
-                    ++iter;
+                if (auto* handler = _paths.find(slugs(), endpoint); handler != nullptr) {
+                    return *handler;
+                } else {
+                    return {};
                 }
-
-                // none of the prefixed paths matched, so try the
-                // unsorted paths without a known prefix
-                for (const auto& [path, callback, instance] : _unsorted_paths) {
-                    // try to match the path to the given endpoint
-                    if (path.match(endpoint, slugs())) {
-                        // we matched the endpoint, return the handler
-                        return { callback, instance };
-                    }
-                }
-
-                // none of the paths matched
-                return {};
             }
 
             /**
@@ -335,9 +181,177 @@ namespace router {
                 return slugs;
             }
 
-            std::vector<entry>  _prefixed_paths;                            // a sorted list of paths with prefixes
-            std::vector<entry>  _unsorted_paths;                            // paths without a prefix, not sorted
-            not_found_handler   _not_found_handler  { nullptr, nullptr  };  // the optional handler for paths not found
+            path_map<callback_type> _paths;             // all registered paths in the table
+            callback_type           _not_found_handler; // the optional handler for paths not found
+    };
+
+    /**
+     *  A routing table, containing paths to route and mapping
+     *  them to a proxy for further processing
+     */
+    template <class return_type, class... arguments, auto first, decltype(first)... rest>
+    class table<proxy<return_type(arguments...), first, rest...>>
+    {
+        public:
+            /**
+             *  The proxy we route to
+             */
+            using proxy_type = proxy<return_type(arguments...), first, rest...>;
+
+            /**
+             *  Add an endpoint to the routing table, the callbacks
+             *  can be registered on the returned proxy
+             *
+             *  @param  endpoint    The path to add
+             */
+            proxy_type& add(std::string_view endpoint)
+            {
+                // add the endpoint to create a proxy
+                return _paths.add(endpoint);
+            }
+
+            /**
+             *  Set a handler for endpoints that are not found
+             *
+             *  @tparam callback    The callback to route to
+             */
+            template <auto callback>
+            std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>>
+            set_not_found()
+            {
+                // store the function pointer, there is no instance
+                _not_found_handler.template set<callback>();
+            }
+
+            /**
+             *  Set a handler for endpoints that are not found
+             *
+             *  @tparam callback    The callback to route to
+             *  @param  instance    The instance to invoke the callback on
+             */
+            template <auto callback>
+            std::enable_if_t<std::is_member_function_pointer_v<decltype(callback)>>
+            set_not_found(typename function_traits<decltype(callback)>::member_type* instance)
+            {
+                // store the function pointer and instance
+                _not_found_handler.template set<callback>(instance);
+            }
+
+            /**
+             *  Set a handler for endpoints without a method handler
+             *
+             *  @tparam callback    The callback to invoke
+             */
+            template <auto callback>
+            std::enable_if_t<!std::is_member_function_pointer_v<decltype(callback)>>
+            set_not_proxied()
+            {
+                // store the function pointer, there is no instance
+                _not_proxied_handler.template set<callback>();
+            }
+
+            /**
+             *  Set a handler for endpoints without a method handler
+             *
+             *  @tparam callback    The callback to invoke
+             *  @param  instance    The instance to invoke the callback on
+             */
+            template <auto callback>
+            std::enable_if_t<std::is_member_function_pointer_v<decltype(callback)>>
+            set_not_proxied(typename function_traits<decltype(callback)>::member_type* instance)
+            {
+                // store the function pointer and instance
+                _not_proxied_handler.template set<callback>(instance);
+            }
+
+            /**
+             *  Check whether a given endpoint can be routed
+             *
+             *  Note that this function ignores the not-found
+             *  handler, since this would otherwise make this
+             *  function return true unconditionally.
+             *
+             *  @param  endpoint    The endpoint to check
+             *  @return Whether the endpoint can be routed
+             */
+            bool routable(std::string_view endpoint) const noexcept
+            {
+                // find the handler for the given endpoint
+                return _paths.find(slugs(), endpoint) != nullptr;
+            }
+
+            /**
+             *  Check whether a fallback handler is installed
+             *
+             *  If a fallback handler is installed and no endpoint is
+             *  available when routing, the fallback handler is used.
+             *  This also means that routing will never fail due to a
+             *  missing endpoint.
+             *
+             *  @return Whether a fallback handler is installed
+             */
+            bool has_not_found_handler() const noexcept
+            {
+                return _not_found_handler.valid();
+            }
+
+            /**
+             *  Route a request to one of the callbacks
+             *
+             *  @param  endpoint    The endpoint to route
+             *  @param  method      The method to proxy to
+             *  @param  parameters  The arguments to give to the callback
+             *  @return The result of the callback
+             *  @throws std::out_of_range
+             */
+            return_type route(std::string_view endpoint, decltype(first) method,  arguments... parameters) const
+            {
+                // find the handler for the given endpoint
+                if (auto proxy = _paths.find(slugs(), endpoint); proxy != nullptr) {
+                    // do we have a handler for the method
+                    if (proxy->get(method).valid()) {
+                        // invoke the callback
+                        return proxy->get(method)(slugs(), std::forward<arguments>(parameters)...);
+                    } else if (_not_proxied_handler.valid()) {
+                        // invoke the missing-method handler
+                        return _not_proxied_handler({}, std::forward<arguments>(parameters)...);
+                    }
+                }
+
+                // do we have a handler for endpoints that aren't registered
+                if (_not_found_handler) {
+                    // invoke the handler
+                    return _not_found_handler({}, std::forward<arguments>(parameters)...);
+                }
+
+                // none of the paths matched
+                throw std::out_of_range{ "Route not matched" };
+            }
+        private:
+            /**
+             *  Alias for the callback type used by the routing table
+             */
+            using callback_type = path_callback<return_type(arguments...)>;
+
+            /**
+             *  Retrieve the slug data
+             *
+             *  @note   This data is stored locally per thread to ensure
+             *          that the table remains thread-safe, and can re-use
+             *          allocated data between calls.
+             *
+             *  @return The slug data
+             */
+            static std::vector<std::string_view>& slugs() noexcept
+            {
+                // the slugs to cache
+                thread_local std::vector<std::string_view> slugs;
+                return slugs;
+            }
+
+            path_map<proxy_type>    _paths;                 // all registered paths in the table
+            callback_type           _not_found_handler;     // the optional handler for paths not found
+            callback_type           _not_proxied_handler;   // the optional handler for when a method is not proxied
     };
 
 }

--- a/include/router/variadic_lookup.h
+++ b/include/router/variadic_lookup.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdexcept>
+#include <cstddef>
+
+
+namespace router {
+
+    template <std::size_t index = 0, auto straw, decltype(straw)... haystack>
+    constexpr std::size_t variadic_lookup(decltype(straw) needle)
+    {
+        if (needle == straw) {
+            return index;
+        } else if constexpr(sizeof...(haystack) > 0) {
+            return variadic_lookup<index + 1, haystack...>(needle);
+        } else {
+            throw std::invalid_argument{ "Lookup failed: needle not found in variadic list" };
+        }
+    }
+
+    template <auto needle, decltype(needle) straw, decltype(needle)... haystack, std::size_t index = 0>
+    constexpr std::size_t variadic_lookup()
+    {
+        if constexpr(needle == straw) {
+            return index;
+        } else if constexpr (sizeof...(haystack) > 0) {
+            return variadic_lookup<needle, haystack..., index + 1>();
+        } else {
+            static_assert(sizeof...(haystack) > 0, "Needle not found in haystack");
+        }
+    }
+
+}

--- a/include/router/wrap_callback.h
+++ b/include/router/wrap_callback.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "function_traits.h"
+#include "variables.h"
+#include <string_view>
+#include <vector>
+
+
+namespace router {
+
+    /**
+     *  Wrap a callback to create a uniform handler
+     *
+     *  @tparam callback    The callback to wrap
+     *  @param  slugs       The slug data from the target
+     *  @param  instance    The instance to invoke the callback on
+     *  @param  parameters  Additional arguments to pass to the callback
+     */
+    template <auto callback, typename return_type, typename... arguments>
+    return_type wrap_callback(const std::vector<std::string_view>& slugs, void* instance, arguments&&... parameters)
+    {
+        // the number of arguments our callback function takes
+        // ignoring the extra variable parameter it may take
+        constexpr std::size_t arity = sizeof...(arguments);
+
+        // traits for the callback function, and the data type used for the variables
+        using traits = function_traits<decltype(callback)>;
+
+        // does the callback require slug parsing?
+        if constexpr (traits::arity == arity) {
+            // is it a member function?
+            if constexpr (!traits::is_member_function) {
+                // it is not, we can invoke the callback directly
+                return callback(std::forward<arguments>(parameters)...);
+            } else {
+                // invoke the function on the given instance
+                return (static_cast<typename traits::member_type*>(instance)->*callback)(std::forward<arguments>(parameters)...);
+            }
+        } else if constexpr (traits::arity == arity + 1 && (is_dto_type_v<std::remove_reference_t<typename traits::template argument_type<arity>>> || is_dto_tuple_v<std::remove_reference_t<typename traits::template argument_type<arity>>>)) {
+            // determine the type used for the slug data, this comes as the optional
+            // last parameter the function may take, elements are zero-based
+            using variable_type = std::remove_reference_t<typename traits::template argument_type<arity>>;
+
+            // create the variables to be filled and try to match the target
+            variable_type variables{};
+
+            // parse the variables
+            to_dto(slugs, variables);
+
+            // is it a member function?
+            if constexpr (!traits::is_member_function) {
+                // invoke the wrapped callback and return the result
+                return callback(std::forward<arguments>(parameters)..., std::move(variables));
+            } else {
+                // invoke the function on the given instance
+                return (static_cast<typename traits::member_type*>(instance)->*callback)(std::forward<arguments>(parameters)..., std::move(variables));
+            }
+        } else {
+            // the variable type is a tuple of the slug arguments
+            // which is unpacked later using std::apply
+            using variable_type = typename traits::template arguments_slice<arity>;
+
+            // create the variables to be filled and try to match the target
+            variable_type variables{};
+
+            // parse the variables
+            to_dto(slugs, variables);
+
+            // is it a member function?
+            if constexpr (!traits::is_member_function) {
+                // invoke the wrapped callback and return the result
+                return std::apply(callback, std::tuple_cat(
+                    std::forward_as_tuple(std::forward<arguments>(parameters)...),
+                    std::move(variables)
+                ));
+            } else {
+                // invoke the function on the given instance
+                return std::apply(callback, std::tuple_cat(
+                    std::forward_as_tuple(static_cast<typename traits::member_type*>(instance)),
+                    std::forward_as_tuple(std::forward<arguments>(parameters)...),
+                    std::move(variables)
+                ));
+            }
+        }
+    }
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(test-sources
     table.cpp
     variables.cpp
     tuple_slice.cpp
+    proxy_table.cpp
 )
 
 add_executable(test ${test-sources})

--- a/tests/proxy_table.cpp
+++ b/tests/proxy_table.cpp
@@ -1,0 +1,76 @@
+#include "catch2.hpp"
+#include <router/table.h>
+#include <iostream>
+
+
+TEST_CASE("paths and methods can be matched", "[path-method]")
+{
+    // the methods to support
+    enum class method
+    {
+        get,
+        put,
+        post
+    };
+
+    // an empty table to test with
+    router::table<router::proxy<void(), method::get, method::put, method::post>> table;
+
+    SECTION("never route on an empty table") {
+        // the table is empty, so all attempts to route
+        // will yield a out of range condition
+        REQUIRE_THROWS_AS(table.route("/test", method::get), std::out_of_range);
+        REQUIRE(table.routable("/test") == false);
+        REQUIRE(table.has_not_found_handler() == false);
+    }
+
+    SECTION("404 handler") {
+        struct not_found_handler
+        {
+            void handle_404() { handler_invoked = true; }
+            bool handler_invoked{ false };
+        };
+
+        not_found_handler tester;
+
+        table.set_not_found<&not_found_handler::handle_404>(&tester);
+        table.route("/wherever/not/found", method::get);
+        REQUIRE(table.routable("/wherever/not/found") == false);
+        REQUIRE(table.has_not_found_handler() == true);
+
+        REQUIRE(tester.handler_invoked == true);
+    }
+
+    SECTION("missing method on valid route") {
+        struct callback_tester
+        {
+            void handle_404() { not_found_invoked = true; }
+            bool not_found_invoked{ false };
+
+            void handle_405() { method_not_allowed = true; }
+            bool method_not_allowed{ false };
+
+            void handle_get() { get_invoked = true; }
+            bool get_invoked{ false };
+        };
+
+        callback_tester tester;
+
+        table.add("/callback")
+            .set<method::get, &callback_tester::handle_get>(&tester);
+
+        table.set_not_found<&callback_tester::handle_404>(&tester);
+        table.route("/callback", method::post);
+        REQUIRE(table.routable("/callback") == true);
+        REQUIRE(table.has_not_found_handler() == true);
+
+        REQUIRE(tester.not_found_invoked == true);
+
+        // now set up a handler for missing method specifically
+        table.set_not_proxied<&callback_tester::handle_405>(&tester);
+        table.route("/callback", method::post);
+
+        REQUIRE(tester.method_not_allowed == true);
+    }
+
+}


### PR DESCRIPTION
This allows setting multiple handlers on a single endpoint, so that a
single route can handle e.g. a GET, a POST or a PUT.